### PR TITLE
add support for anyone to encrypt secrets on ostro.ws, not just me

### DIFF
--- a/cmd/wasm/registerEncryptor.go
+++ b/cmd/wasm/registerEncryptor.go
@@ -41,7 +41,7 @@ func getValidPublicKeyWrapper() js.Func {
 			}
 			if rsahelpers.IsValidSendMeASecretKey(parsed) {
 				if validKey != "" {
-					return "Too many valid keys"
+					return "Too many valid keys. Can't decide."
 				}
 				validKey = key
 			}

--- a/cmd/wasm/registerEncryptor.go
+++ b/cmd/wasm/registerEncryptor.go
@@ -1,18 +1,22 @@
 package main
 
 import (
+	"crypto/rsa"
+	"fmt"
 	"syscall/js"
 
-	"github.com/ostrowr/send-me-a-secret/internal/encryptor"
+	"github.com/ostrowr/send-me-a-secret/internal/githubapi"
+	"github.com/ostrowr/send-me-a-secret/internal/rsahelpers"
 )
 
 func encryptWrapper() js.Func {
 	f := js.FuncOf(func(this js.Value, args []js.Value) interface{} {
-		if len(args) != 1 {
+		if len(args) != 2 {
 			return "No message provided."
 		}
-		message := args[0].String()
-		encrypted, err := encryptor.Encrypt([]byte(message))
+		pubKey := interface{}(args[0]).(*rsa.PublicKey)
+		message := args[1].String()
+		encrypted, err := rsahelpers.Encrypt(pubKey, []byte(message))
 		if err != nil {
 			return err.Error()
 		}
@@ -21,7 +25,28 @@ func encryptWrapper() js.Func {
 	return f
 }
 
+func getPublicKeyWrapper() js.Func {
+	f := js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+		if len(args) != 1 {
+			return "No message provided."
+		}
+		username := args[0].String()
+		client := githubapi.GetGithubClient("")
+		fmt.Println(client)
+		publicKey, err := githubapi.GetPublicKeyFromGithubUnauthenticated(client, username, rsahelpers.IsValidSendMeASecretKey)
+		if err != nil {
+			return err.Error()
+		}
+		fmt.Println(publicKey)
+		return username
+
+		// return publicKey.E
+	})
+	return f
+}
+
 func main() {
 	js.Global().Set("encrypt", encryptWrapper())
+	js.Global().Set("getPublicKey", getPublicKeyWrapper())
 	<-make(chan bool) // never exit
 }

--- a/cmd/wasm/registerEncryptor.go
+++ b/cmd/wasm/registerEncryptor.go
@@ -1,22 +1,23 @@
 package main
 
 import (
-	"crypto/rsa"
-	"fmt"
 	"syscall/js"
 
-	"github.com/ostrowr/send-me-a-secret/internal/githubapi"
 	"github.com/ostrowr/send-me-a-secret/internal/rsahelpers"
 )
 
 func encryptWrapper() js.Func {
 	f := js.FuncOf(func(this js.Value, args []js.Value) interface{} {
 		if len(args) != 2 {
-			return "No message provided."
+			return "Must provide message and public key."
 		}
-		pubKey := interface{}(args[0]).(*rsa.PublicKey)
-		message := args[1].String()
-		encrypted, err := rsahelpers.Encrypt(pubKey, []byte(message))
+		message := args[0].String()
+		publicKeyBytes := []byte(args[1].String())
+		publicKey, err := rsahelpers.SSHPubKeyToRSAPubKey(publicKeyBytes)
+		if err != nil {
+			return err.Error()
+		}
+		encrypted, err := rsahelpers.Encrypt(publicKey, []byte(message))
 		if err != nil {
 			return err.Error()
 		}
@@ -30,17 +31,13 @@ func getPublicKeyWrapper() js.Func {
 		if len(args) != 1 {
 			return "No message provided."
 		}
-		username := args[0].String()
-		client := githubapi.GetGithubClient("")
-		fmt.Println(client)
-		publicKey, err := githubapi.GetPublicKeyFromGithubUnauthenticated(client, username, rsahelpers.IsValidSendMeASecretKey)
-		if err != nil {
-			return err.Error()
-		}
-		fmt.Println(publicKey)
-		return username
 
-		// return publicKey.E
+		// 1. Get a list of all public keys (js-land)
+		// 2. Pass that list into this function, which figures out which (if any) are valid
+		// 3. Return the (string) public key back from this function
+		// 4. Run encrypt using the public key returned from this function, parsed yet again.
+
+		return `ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACPACro6jmd+F8ZkcS2lmtRsIiuEUwjXDyxr0ZF1U9fBypwF2LzZTqQh0WykHcn0ETycRUonSL8feTLxaPCjv0puUdS7vY16LZsFDDyr4siRfcJFqkD8psf55Fm5bZYvnLkUgUil4dwhk3pKS59OzZrl5su0j01OUf0Ly1WzdiONNtr2U+fNrP5PB3mHCgyhD3rVMEAtVAahbah7PF1aSoCqs4Xazhg5yaGTUiqBREYhqXbQsLNZL4vxLURFF95Ngqn9srWN6neDmyjuWVrH9yKrEnsGYyWcvWdATLj/PslSVsdZ9RKbchxlEoNQVECPV7KVhkaCBGOnQ+tg++7svKhM/NacgoJE/qOnAWMK2mjBEOeuPEgA9qQibD1Ps0XwkHDDyMa9HHCNWTme+s67RUy84mc7wImDJYFn/hTKQgRdY6gTJmOhP/hBsBhbU1U/DYOUXtUzUoE+2eIpewSYshwdM9F7xGwVH+F1ArcUej67Fxl5Fty7talvIyJSYzr10ZIgBxxWijDzZ+wlIn7jwxHIeaZ3ilVPqloBJN/G9zDJZArwm59ALJ7JARDU+FQxXwHxO+TR2AhIGdMg3IF0JVpmQB0rXu/7bip2JraM936DM02494wJj15fxCWBacIugp895gqI8MdacUKQHlCmuDzqXuy67wpI2mokm339rQpG0uyO/U3Ese7i47IdZfHP5JTGNGv7IKAxGtY2Cvmsz/sCDa9ZRED+EzKAMTDTfqF/8HdhsR3WEVsBIwOOX9`
 	})
 	return f
 }

--- a/cmd/wasm/registerEncryptor.go
+++ b/cmd/wasm/registerEncryptor.go
@@ -28,9 +28,9 @@ func encryptWrapper() js.Func {
 
 func getPublicKeyWrapper() js.Func {
 	f := js.FuncOf(func(this js.Value, args []js.Value) interface{} {
-		if len(args) != 1 {
-			return "No message provided."
-		}
+		// if len(args) != 1 {
+		// 	return "No message provided."
+		// }
 
 		// 1. Get a list of all public keys (js-land)
 		// 2. Pass that list into this function, which figures out which (if any) are valid

--- a/internal/githubapi/githubapi.go
+++ b/internal/githubapi/githubapi.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"crypto/rsa"
 	"errors"
+	"fmt"
 
 	"github.com/google/go-github/v33/github"
 	"github.com/ostrowr/send-me-a-secret/internal/rsahelpers"
@@ -55,15 +56,22 @@ var ErrTooManyValidKeys = errors.New("multiple valid keys found for user; can't 
 // (keyLength is hackily used to identify keys generated for send-me-a-secret, since the title is not publicly available.)
 // If there are no valid keys or if there is more than one maching key, this returns an error.
 func GetPublicKeyFromGithubUnauthenticated(githubClient *github.Client, username string, isValidKey func(*rsa.PublicKey) bool) (*rsa.PublicKey, error) {
+	fmt.Println("here1")
 	ctx := context.Background()
 	options := github.ListOptions{
 		Page:    1,
 		PerPage: 100,
 	}
+	fmt.Println("here2")
+
 	allPublicKeys := make([]*github.Key, 0, 10)
 	for {
 		// TODO deal with rate limiting; probably in GetGithubClient
+		fmt.Println("here4")
+
 		keys, response, err := githubClient.Users.ListKeys(ctx, username, &options)
+		fmt.Println("here5")
+
 		if err != nil {
 			return nil, err
 		}
@@ -73,6 +81,8 @@ func GetPublicKeyFromGithubUnauthenticated(githubClient *github.Client, username
 		}
 		options.Page = response.NextPage
 	}
+
+	fmt.Println("here3")
 
 	validKeys := make([]*rsa.PublicKey, 0, 1)
 

--- a/internal/githubapi/githubapi.go
+++ b/internal/githubapi/githubapi.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"crypto/rsa"
 	"errors"
-	"fmt"
 
 	"github.com/google/go-github/v33/github"
 	"github.com/ostrowr/send-me-a-secret/internal/rsahelpers"
@@ -56,21 +55,17 @@ var ErrTooManyValidKeys = errors.New("multiple valid keys found for user; can't 
 // (keyLength is hackily used to identify keys generated for send-me-a-secret, since the title is not publicly available.)
 // If there are no valid keys or if there is more than one maching key, this returns an error.
 func GetPublicKeyFromGithubUnauthenticated(githubClient *github.Client, username string, isValidKey func(*rsa.PublicKey) bool) (*rsa.PublicKey, error) {
-	fmt.Println("here1")
 	ctx := context.Background()
 	options := github.ListOptions{
 		Page:    1,
 		PerPage: 100,
 	}
-	fmt.Println("here2")
 
 	allPublicKeys := make([]*github.Key, 0, 10)
 	for {
 		// TODO deal with rate limiting; probably in GetGithubClient
-		fmt.Println("here4")
 
 		keys, response, err := githubClient.Users.ListKeys(ctx, username, &options)
-		fmt.Println("here5")
 
 		if err != nil {
 			return nil, err
@@ -81,8 +76,6 @@ func GetPublicKeyFromGithubUnauthenticated(githubClient *github.Client, username
 		}
 		options.Page = response.NextPage
 	}
-
-	fmt.Println("here3")
 
 	validKeys := make([]*rsa.PublicKey, 0, 1)
 

--- a/web/browser-me-a-secret/src/App.svelte
+++ b/web/browser-me-a-secret/src/App.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	let encryptor: ((message: string) => string) | undefined;
+	let encryptor: ((message: string, publicKey: string) => string) | undefined;
+	let publicKeyer: ((x: string) => string) | undefined;
 	const go = new Go();
 	WebAssembly.instantiateStreaming(
 		fetch("./registerEncryptor.wasm"),
@@ -7,6 +8,7 @@
 	).then((result) => {
 		go.run(result.instance);
 		encryptor = encrypt
+		publicKeyer = getPublicKey
 	});
 	let message: string | undefined;
 	let ciphertextElement: HTMLTextAreaElement;
@@ -18,6 +20,8 @@
 	}
 
 	const queryString = window.location.search;
+	console.log(queryString)
+	console.log(publicKeyer?.("sdf"))
 </script>
 
 <style>
@@ -40,10 +44,10 @@
 	<h4>Encrypt a short message using my public key</h4>
 	<textarea bind:value={message} placeholder="Type message here"></textarea>
 	<h3>Encrypted</h3>
-	{#if !encryptor}
+	{#if !encryptor || !publicKeyer}
 		<p>Loading encryptor...</p>
 	{:else}
-		<textarea bind:this={ciphertextElement} readonly>{encryptor(message ?? "")}</textarea>
+		<textarea bind:this={ciphertextElement} readonly>{encryptor(message ?? "", publicKeyer("d"))}</textarea>
 	{/if}
 	<button on:click={copyCiphertext}>Copy</button>
 </main>

--- a/web/browser-me-a-secret/src/App.svelte
+++ b/web/browser-me-a-secret/src/App.svelte
@@ -16,6 +16,8 @@
 			ciphertextElement.setSelectionRange(0, 99999);
 			document.execCommand("copy");
 	}
+
+	const queryString = window.location.search;
 </script>
 
 <style>

--- a/web/browser-me-a-secret/src/App.svelte
+++ b/web/browser-me-a-secret/src/App.svelte
@@ -38,8 +38,6 @@ import GithubSelector from "./components/GithubSelector.svelte";
 			<p>...waiting</p>
 		{:then key}
 			<Encryptor publicKey={key} encryptFn={encryptFn} username={githubUsername}/>
-		{:catch error}
-			<p style="color: red">{error.message}</p>
 		{/await}
 	{/if}
 

--- a/web/browser-me-a-secret/src/App.svelte
+++ b/web/browser-me-a-secret/src/App.svelte
@@ -1,27 +1,21 @@
 <script lang="ts">
-	let encryptor: ((message: string, publicKey: string) => string) | undefined;
-	let publicKeyer: ((x: string) => string) | undefined;
+import Encryptor from "./components/Encryptor.svelte";
+
+	let encryptFn: ((message: string, publicKey: string) => string) | undefined;
+	let getPublicKeyFn: ((x: string) => string) | undefined;
 	const go = new Go();
 	WebAssembly.instantiateStreaming(
 		fetch("./registerEncryptor.wasm"),
 		go.importObject
 	).then((result) => {
 		go.run(result.instance);
-		encryptor = encrypt
-		publicKeyer = getPublicKey
+		encryptFn = encrypt
+		getPublicKeyFn = getPublicKey
 	});
-	let message: string | undefined;
-	let ciphertextElement: HTMLTextAreaElement;
-
-	const copyCiphertext = () => {
-			ciphertextElement.select();
-			ciphertextElement.setSelectionRange(0, 99999);
-			document.execCommand("copy");
-	}
-
 	const queryString = window.location.search;
 	console.log(queryString)
-	console.log(publicKeyer?.("sdf"))
+	let publicKey: string | undefined;
+	$: publicKey = getPublicKeyFn?.("TODO");
 </script>
 
 <style>
@@ -31,25 +25,17 @@
 		max-width: 240px;
 		margin: 0 auto;
 	}
-	textarea { width: 100%; height: 200px; }
-
-	textarea:read-only {
-  	background-color: #ccc;
-	}
 </style>
 
 
 <main>
 	<h5>Send Me a Secret (<a href="https://github.com/ostrowr/send-me-a-secret">GitHub</a>)</h5>
-	<h4>Encrypt a short message using my public key</h4>
-	<textarea bind:value={message} placeholder="Type message here"></textarea>
-	<h3>Encrypted</h3>
-	{#if !encryptor || !publicKeyer}
-		<p>Loading encryptor...</p>
+	{#if !encryptFn || !publicKey}
+		Loading...
 	{:else}
-		<textarea bind:this={ciphertextElement} readonly>{encryptor(message ?? "", publicKeyer("d"))}</textarea>
+		<Encryptor publicKey={publicKey} encryptFn={encryptFn}/>
 	{/if}
-	<button on:click={copyCiphertext}>Copy</button>
+
 </main>
 
 

--- a/web/browser-me-a-secret/src/components/Encryptor.svelte
+++ b/web/browser-me-a-secret/src/components/Encryptor.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  export let publicKey: string;
+  export let encryptFn: (message: string, publicKey: string) => string;
+
+  let message: string | undefined;
+
+  let ciphertextElement: HTMLTextAreaElement;
+
+  const copyCiphertext = () => {
+			ciphertextElement.select();
+			ciphertextElement.setSelectionRange(0, 99999);
+			document.execCommand("copy");
+	}
+</script>
+
+<style>
+	textarea { width: 100%; height: 200px; }
+
+	textarea:read-only {
+  	background-color: #ccc;
+	}
+</style>
+
+<h4>Encrypt a short message using my public key</h4>
+<textarea bind:value={message} placeholder="Type message here"></textarea>
+<h3>Encrypted</h3>
+<textarea bind:this={ciphertextElement} readonly>{encryptFn(message ?? "", publicKey ?? "")}</textarea>
+<button on:click={copyCiphertext}>Copy</button>

--- a/web/browser-me-a-secret/src/components/Encryptor.svelte
+++ b/web/browser-me-a-secret/src/components/Encryptor.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   export let publicKey: string;
   export let encryptFn: (message: string, publicKey: string) => string;
+  export let username: string;
 
   let message: string | undefined;
 
@@ -21,7 +22,7 @@
 	}
 </style>
 
-<h4>Encrypt a short message using my public key</h4>
+<h4>Encrypt a short message using {username}'s public key</h4>
 <textarea bind:value={message} placeholder="Type message here"></textarea>
 <h3>Encrypted</h3>
 <textarea bind:this={ciphertextElement} readonly>{encryptFn(message ?? "", publicKey ?? "")}</textarea>

--- a/web/browser-me-a-secret/src/components/GithubSelector.svelte
+++ b/web/browser-me-a-secret/src/components/GithubSelector.svelte
@@ -11,7 +11,8 @@
       }
     })
     if (!response.ok) {
-      throw new Error(response.statusText)
+      const errorJson = await response.json()
+      throw new Error(`Error getting keys from GitHub. Code: ${response.status}, Message: ${errorJson.message}`)
     }
     const keys: Key[] = await response.json()
     const validKey = getValidPublicKeyFn(keys.map(k => k.key))
@@ -24,7 +25,9 @@
 </script>
 
 <style>
-
+  pre {
+    overflow: auto;
+  }
 </style>
 
 <input bind:value={username}>

--- a/web/browser-me-a-secret/src/components/GithubSelector.svelte
+++ b/web/browser-me-a-secret/src/components/GithubSelector.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  export let username: string;
+  export let getValidPublicKeyFn: (possibleKeys: string[]) => string;
+  export let publicKeyPromise: Promise<string>;
+  type Key = {id: number, key: string}
+
+  async function getKeyForUser(username: string): Promise<string> {
+    const response = await fetch(`https://api.github.com/users/${username}/keys`, {
+      headers: {
+        Accept: "application/vnd.github.v3+json"
+      }
+    })
+    if (!response.ok) {
+      throw new Error(response.statusText)
+    }
+    const keys: Key[] = await response.json()
+    const validKey = getValidPublicKeyFn(keys.map(k => k.key))
+    return validKey;
+  }
+
+  // todo: don't make a request every time this changes. Rate limited
+  $: publicKeyPromise = getKeyForUser(username)
+
+</script>
+
+<style>
+
+</style>
+
+<input bind:value={username}>
+
+{#await publicKeyPromise}
+	<p>...waiting</p>
+{:then key}
+  <p>{username}'s key is</p>
+  <pre>{key}</pre>
+{:catch error}
+	<p style="color: red">{error.message}</p>
+{/await}

--- a/web/browser-me-a-secret/src/ts-definitions/global.d.ts
+++ b/web/browser-me-a-secret/src/ts-definitions/global.d.ts
@@ -4,4 +4,4 @@ declare class Go {
 }
 
 declare var encrypt: any;
-declare var getPublicKey: any;
+declare var getValidPublicKey: any;

--- a/web/browser-me-a-secret/src/ts-definitions/global.d.ts
+++ b/web/browser-me-a-secret/src/ts-definitions/global.d.ts
@@ -4,3 +4,4 @@ declare class Go {
 }
 
 declare var encrypt: any;
+declare var getPublicKey: any;


### PR DESCRIPTION
Very basic ui support for typing in a github username and fetching their key. Doesn't attempt to make the UI usable at all, but allows anyone who runs `send-me-a-secret initialize` to send someone to ostro.ws/send-me-a-secret to encrypt a secret for them.

Currently defaults to `ostrowr`.